### PR TITLE
Button rework and joystick bug fix

### DIFF
--- a/Assets/Prefabs/Camera/CameraSwapper.prefab
+++ b/Assets/Prefabs/Camera/CameraSwapper.prefab
@@ -46,6 +46,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   transitionTime: 0.5
+  tempCamera: {fileID: 4286855124947821587}
 --- !u!1001 &3524649814999923565
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -110,5 +111,10 @@ PrefabInstance:
 --- !u!4 &3426391304277598593 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2262758550990445292, guid: bb44b91a79d9d974cb2fd4157acf1c5a, type: 3}
+  m_PrefabInstance: {fileID: 3524649814999923565}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4286855124947821587 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 835393889155456894, guid: bb44b91a79d9d974cb2fd4157acf1c5a, type: 3}
   m_PrefabInstance: {fileID: 3524649814999923565}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/ScreenModuleComponents/Controls/Button.prefab
+++ b/Assets/Prefabs/ScreenModuleComponents/Controls/Button.prefab
@@ -1,103 +1,95 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &8406437434568329821
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.39
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.39000002
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.39000005
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_ConstrainProportionsScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_Name
-      value: Button
-      objectReference: {fileID: 0}
-    - target: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      propertyPath: m_Name
-      value: Button
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4083146366794572940}
-    - targetCorrespondingSourceObject: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 5638457849443459960}
-    - targetCorrespondingSourceObject: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1183287102964617810}
-    - targetCorrespondingSourceObject: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 917459989828467551}
-  m_SourcePrefab: {fileID: 100100000, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
---- !u!1 &1083355285709501578 stripped
+--- !u!1 &1083355285709501578
 GameObject:
-  m_CorrespondingSourceObject: {fileID: -314843321673679145, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
-  m_PrefabInstance: {fileID: 8406437434568329821}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6560390334870494027}
+  - component: {fileID: 8444477532701915563}
+  - component: {fileID: 7705953493214242833}
+  - component: {fileID: 4083146366794572940}
+  - component: {fileID: 5638457849443459960}
+  - component: {fileID: 1183287102964617810}
+  - component: {fileID: 917459989828467551}
+  m_Layer: 2
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6560390334870494027
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083355285709501578}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8296496051653750198}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8444477532701915563
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083355285709501578}
+  m_Mesh: {fileID: -1337566010273431828, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
+--- !u!23 &7705953493214242833
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1083355285709501578}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &4083146366794572940
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -191,3 +183,122 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &2409224078468981094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8328188797489809579}
+  - component: {fileID: 1327049788501363704}
+  - component: {fileID: 3272458496518583419}
+  m_Layer: 0
+  m_Name: ButtonHousing
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8328188797489809579
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2409224078468981094}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8296496051653750198}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1327049788501363704
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2409224078468981094}
+  m_Mesh: {fileID: 1102768643795723118, guid: b0740c4a3a43a424db8998d6ac837f87, type: 3}
+--- !u!23 &3272458496518583419
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2409224078468981094}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8676399771372549900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8296496051653750198}
+  m_Layer: 0
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8296496051653750198
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8676399771372549900}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.39, y: 0.39000002, z: 0.39000005}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 6560390334870494027}
+  - {fileID: 8328188797489809579}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/ScreenModuleComponents/Controls/Joystick.prefab
+++ b/Assets/Prefabs/ScreenModuleComponents/Controls/Joystick.prefab
@@ -31,108 +31,216 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1162395519387251977}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &7553563647084928886
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.31
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.31
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.30999997
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_ConstrainProportionsScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7928556202912232333, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      propertyPath: m_Name
-      value: Joystick
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: -508327808626840961, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 6292212979230254755}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: -7928556202912232333, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8711602032157422467}
-    - targetCorrespondingSourceObject: {fileID: -7928556202912232333, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 719767272208025492}
-    - targetCorrespondingSourceObject: {fileID: -7928556202912232333, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1584031986601391730}
-    - targetCorrespondingSourceObject: {fileID: -7928556202912232333, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 8903971015918142052}
-  m_SourcePrefab: {fileID: 100100000, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
---- !u!4 &1162395519387251977 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -508327808626840961, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-  m_PrefabInstance: {fileID: 7553563647084928886}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &8731277060112077573 stripped
+--- !u!1 &6181350317000436479
 GameObject:
-  m_CorrespondingSourceObject: {fileID: -7928556202912232333, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
-  m_PrefabInstance: {fileID: 7553563647084928886}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 795025549117891945}
+  - component: {fileID: 7884112744237033855}
+  - component: {fileID: 3763081298945613341}
+  m_Layer: 0
+  m_Name: JoystickHousing
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &795025549117891945
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6181350317000436479}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0.19996959, z: -0.0037311744}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8023478711174068381}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7884112744237033855
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6181350317000436479}
+  m_Mesh: {fileID: -8076150261172120912, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
+--- !u!23 &3763081298945613341
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6181350317000436479}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &7211054429271761447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8023478711174068381}
+  m_Layer: 0
+  m_Name: Joystick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8023478711174068381
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7211054429271761447}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.31, y: 0.31, z: 0.30999997}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1162395519387251977}
+  - {fileID: 795025549117891945}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8731277060112077573
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1162395519387251977}
+  - component: {fileID: 4514295490794932806}
+  - component: {fileID: 1082242939356021955}
+  - component: {fileID: 8711602032157422467}
+  - component: {fileID: 719767272208025492}
+  - component: {fileID: 1584031986601391730}
+  - component: {fileID: 8903971015918142052}
+  m_Layer: 2
+  m_Name: Joystick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1162395519387251977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8731277060112077573}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0.19996959, z: -0.0037311744}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6292212979230254755}
+  m_Father: {fileID: 8023478711174068381}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4514295490794932806
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8731277060112077573}
+  m_Mesh: {fileID: -6177378950161749060, guid: bf183adcc67b7bf4ab91b7934d5c4092, type: 3}
+--- !u!23 &1082242939356021955
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8731277060112077573}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &8711602032157422467
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -168,6 +276,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moveStick: {fileID: 11400000, guid: 9962c77e9758a54068799d9cb1188386, type: 2}
   speed: 0.3
+  tipTransform: {fileID: 6292212979230254755}
 --- !u!114 &1584031986601391730
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ScreenModuleComponents/Controls/Knob.prefab
+++ b/Assets/Prefabs/ScreenModuleComponents/Controls/Knob.prefab
@@ -31,111 +31,97 @@ Transform:
   m_Children: []
   m_Father: {fileID: 3908829445689363153}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1245767380906152919
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.43
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.43
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.43
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_ConstrainProportionsScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_Name
-      value: Knob
-      objectReference: {fileID: 0}
-    - target: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_Name
-      value: Knob
-      objectReference: {fileID: 0}
-    - target: {fileID: 8174055074329208553, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      propertyPath: m_Name
-      value: KnobCasing
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: -6379584722140866298, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3349985057976126660}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 588751199392276300}
-    - targetCorrespondingSourceObject: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3072735464028117386}
-    - targetCorrespondingSourceObject: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1302077197011043393}
-    - targetCorrespondingSourceObject: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4124985643143645581}
-  m_SourcePrefab: {fileID: 100100000, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
---- !u!1 &2006906332182609502 stripped
+--- !u!1 &2006906332182609502
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 761157231748574601, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-  m_PrefabInstance: {fileID: 1245767380906152919}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3908829445689363153}
+  - component: {fileID: 3661548212049179494}
+  - component: {fileID: 4008600483213445250}
+  - component: {fileID: 588751199392276300}
+  - component: {fileID: 3072735464028117386}
+  - component: {fileID: 1302077197011043393}
+  - component: {fileID: 4124985643143645581}
+  m_Layer: 2
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3908829445689363153
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2006906332182609502}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.008044434, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3349985057976126660}
+  m_Father: {fileID: 1640264264060204092}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3661548212049179494
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2006906332182609502}
+  m_Mesh: {fileID: -5018585574976106752, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
+--- !u!23 &4008600483213445250
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2006906332182609502}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &588751199392276300
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -171,6 +157,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   turnKnob: {fileID: 0}
   maxTurnAngle: 270
+  tipTransform: {fileID: 3349985057976126660}
 --- !u!114 &1302077197011043393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -227,8 +214,122 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!4 &3908829445689363153 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -6379584722140866298, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
-  m_PrefabInstance: {fileID: 1245767380906152919}
+--- !u!1 &2128147657043160710
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1640264264060204092}
+  m_Layer: 0
+  m_Name: Knob
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1640264264060204092
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128147657043160710}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.43, y: 0.43, z: 0.43}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 3908829445689363153}
+  - {fileID: 8830703089694017236}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6933794228047787326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8830703089694017236}
+  - component: {fileID: 6213817067999365087}
+  - component: {fileID: 2508915088386952988}
+  m_Layer: 0
+  m_Name: KnobCasing
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8830703089694017236
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6933794228047787326}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1.661178, y: 1.661178, z: 1.661178}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1640264264060204092}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6213817067999365087
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6933794228047787326}
+  m_Mesh: {fileID: -6277432782218162957, guid: 541a8330337f31c69add44eb1b0dcca2, type: 3}
+--- !u!23 &2508915088386952988
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6933794228047787326}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/Assets/Scripts/Camera/CameraSwapper.cs
+++ b/Assets/Scripts/Camera/CameraSwapper.cs
@@ -5,7 +5,7 @@ using System.Collections;
 public class CameraSwapper : MonoBehaviour
 {
     [SerializeField] private float transitionTime = 0.05f;
-    private GameObject tempCamera;
+    [SerializeField] private GameObject tempCamera;
     
     public static CameraSwapper Instance = null;
 
@@ -21,40 +21,36 @@ public class CameraSwapper : MonoBehaviour
             Destroy(gameObject);
         }
         DontDestroyOnLoad(gameObject);
-        
-        tempCamera = transform.GetChild(0).gameObject;
     }
     
     // The action delegate code is run when the transition is completed.
-    public void SwapCameras(Camera cameraFrom, Camera cameraTo, Action action)
+    public void SwapCameras(Camera cameraStart, Camera cameraEnd, Action action)
     {
-        StartCoroutine(Transition(cameraFrom, cameraTo, action));
+        StartCoroutine(Transition(cameraStart, cameraEnd, action));
     }
     
-    public IEnumerator Transition(Camera cameraFrom, Camera cameraTo, Action action)
+    public IEnumerator Transition(Camera cameraStart, Camera cameraEnd, Action action)
     {
-        Transform from = cameraFrom.gameObject.transform;
-        Transform to = cameraTo.gameObject.transform;
+        Transform start = cameraStart.gameObject.transform;
+        Transform end = cameraEnd.gameObject.transform;
 
-        transform.position = from.position;
-        Vector3 startPosition = from.position;
-
-        Quaternion startRotation = from.rotation;
-        float timer = 0f;
-
-        cameraFrom.gameObject.SetActive(false);
+        start.GetPositionAndRotation(out Vector3 startPosition, out Quaternion startRotation);
+        
+        cameraStart.gameObject.SetActive(false);
         tempCamera.SetActive(true);
         
-        while((transform.position - to.position).magnitude > 0.05f)
+        float timer = 0f;
+        while((tempCamera.transform.position - end.position).magnitude > 0.05f)
         {
-            transform.position = Vector3.Slerp(startPosition, to.position, timer / transitionTime);
-            transform.rotation = Quaternion.Slerp(startRotation, to.rotation, timer / transitionTime);
+            Vector3 newPosition = Vector3.Slerp(startPosition, end.position, timer / transitionTime);
+            Quaternion newRotation = Quaternion.Slerp(startRotation, end.rotation, timer / transitionTime);
+            tempCamera.transform.SetPositionAndRotation(newPosition, newRotation);
             timer += Time.deltaTime;
             yield return null;
         }
         
         tempCamera.SetActive(false);
-        cameraTo.gameObject.SetActive(true);
+        cameraEnd.gameObject.SetActive(true);
 
         action();
     }

--- a/Assets/Scripts/ScreenModuleComponents/Controls/ButtonController.cs
+++ b/Assets/Scripts/ScreenModuleComponents/Controls/ButtonController.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+    using UnityEngine;
 using System.Collections;
 
 public class ButtonController : MonoBehaviour
@@ -7,7 +7,7 @@ public class ButtonController : MonoBehaviour
     [SerializeField] private VoidEventChannelSO buttonUp;
     [SerializeField] private Mode mode = Mode.Hold;
     [SerializeField] private float pressTime = 0.1f;
-    private float pressDistance = 0.1f;
+    private readonly float pressDistance = 0.1f;
     private float defaultYPosition;
     private float pressVelocity;
     private bool isTargetStatePressed;
@@ -62,13 +62,13 @@ public class ButtonController : MonoBehaviour
         {
             this.isTargetStatePressed = isTargetStatePressed;
 
-            if (isTargetStatePressed)
+            if (isTargetStatePressed && buttonDown != null)
             {
-                buttonDown?.RaiseEvent();
+                buttonDown.RaiseEvent();
             }
-            else
+            else if (!isTargetStatePressed && buttonUp != null)
             {
-                buttonUp?.RaiseEvent();
+                buttonUp.RaiseEvent();
             }
 
             if (moveButton != null)

--- a/Assets/Scripts/ScreenModuleComponents/Controls/KnobController.cs
+++ b/Assets/Scripts/ScreenModuleComponents/Controls/KnobController.cs
@@ -7,6 +7,7 @@ public class KnobController : MonoBehaviour
     [SerializeField] private FloatEventChannelSO turnKnob;
     [Tooltip("0 results in free rotation.")]
     [SerializeField] [Range(0f, 360f)] private float maxTurnAngle = 0f;
+    [SerializeField] private Transform tipTransform;
     private bool isBeingControlled;
     private float currentRotation;
     private float lastMouseAngle;
@@ -41,10 +42,10 @@ public class KnobController : MonoBehaviour
         // Only calculated the first time the module is interacted with.
         if (Mathf.Approximately(tipOffsetFromCamera, 0f))
         {
-            Vector3 tipPosition = transform.GetChild(0).position;
-            tipOffsetFromCamera = Vector3.Dot(tipPosition - Camera.main.transform.position,
-                                              Camera.main.transform.forward);
-            distanceToTip = (tipPosition - transform.position).magnitude;
+            Vector3 difference = tipTransform.position - Camera.main.transform.position;
+            tipOffsetFromCamera = Vector3.Dot(difference, Camera.main.transform.forward);
+            
+            distanceToTip = (tipTransform.position - transform.position).magnitude;
         }
     }
     
@@ -92,8 +93,11 @@ public class KnobController : MonoBehaviour
     private void SendInput()
     {
         // Sends a value between 0 and 1 when maxTurnAngle is not 0. Otherwise, send a value equal to 1 per rotation.
-        float divisor = Mathf.Approximately(maxTurnAngle, 0f) ? 360f : maxTurnAngle;
-        turnKnob?.RaiseEvent(currentRotation / divisor);
+        if (turnKnob != null)
+        {
+            float divisor = Mathf.Approximately(maxTurnAngle, 0f) ? 360f : maxTurnAngle;
+            turnKnob.RaiseEvent(currentRotation / divisor);
+        }
     }
 
     // Returns an angle from -180 to 180.


### PR DESCRIPTION
## Overview
Before, the buttons were somewhat buggy and the logic was messy and hard to follow. Cheap fixes to make the buttons feel better only made the logic more complicated, so I opted to rewrite the script. Also, the single-press mode was removed because it wasn't necessary and it didn't feel very natural to use.

The joystick had a bug where it only worked properly if it was facing the correct direction. Now, it works as expected when facing any direction. One thing to note is that the way it is currently implemented, that direction cannot be changed while the script is running.

## Notes
Due to how festive `ButtonController.cs` is when viewing in unified view, it may be better to look at it in split view.

## Testing
All testing materials are in the `ScreenTransition.unity` scene.