### PR TITLE
Change pickup item drop sound based on velocity

### DIFF
--- a/Assets/Audio/SFX/Item/ItemDrop.wav
+++ b/Assets/Audio/SFX/Item/ItemDrop.wav
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:552a110b8a670d9f2655f9d3311a85e92670ba3023b627ad3a359d6849ea4d12
-size 63116
+oid sha256:6be3a0e3ec3c125cdb787d1504d2b31d9db5f43b0fec77581e9c4a5d25c42b76
+size 27680

--- a/Assets/Scripts/ObjectInteraction/Interactables/PickupItem.cs
+++ b/Assets/Scripts/ObjectInteraction/Interactables/PickupItem.cs
@@ -101,9 +101,12 @@ public class PickupItem : MonoBehaviour, IInteractable
         }
     }
 
-    private void OnCollisionEnter()
+    private void OnCollisionEnter(Collision collision)
     {
-        AudioManager.Instance.PlaySound(MixerType.SFX, SoundType.ItemDrop, 0.05f, transform.position);
+        float soundVolume = Mathf.InverseLerp(0, 3, collision.relativeVelocity.magnitude);
+        soundVolume *= 0.05f;
+
+        AudioManager.Instance.PlaySound(MixerType.SFX, SoundType.ItemDrop, soundVolume, transform.position);
     }
 
     public float GetInteractDistance()


### PR DESCRIPTION
Previously the pickup items would play a sound anytime they hit an object at the same volume. Now objects moving slow enough will play a quieter sound.