### PR TITLE
Fixed win/loss in drill minigame causing errors, commented out debug …

### DIFF
--- a/Assets/Scripts/ObjectInteraction/Usables/Coffee.cs
+++ b/Assets/Scripts/ObjectInteraction/Usables/Coffee.cs
@@ -15,7 +15,7 @@ public class Coffee : MonoBehaviour, IUsable
         if (LevelManager.Instance != null && LevelManager.Instance.currentSession != null)
         {
             LevelManager.Instance.currentSession.coffeeDrank++;
-            Debug.Log($"Current Coffees Drank is: {LevelManager.Instance.currentSession.coffeeDrank}");
+            //Debug.Log($"Current Coffees Drank is: {LevelManager.Instance.currentSession.coffeeDrank}");
         }
         else
         {

--- a/Assets/Scripts/SceneObjects/CameraStateByLevel.cs
+++ b/Assets/Scripts/SceneObjects/CameraStateByLevel.cs
@@ -14,7 +14,7 @@ public class CameraStateByLevel : MonoBehaviour
             for(int i=0;i<daysDisabled.Length;i++){
                 if(daysDisabled[i]==LevelManager.Instance.currentSession.currentDay){
                     gameObject.SetActive(false);
-                    Debug.Log("Camera disabled!");
+                    //Debug.Log("Camera disabled!");
                 }
             }    
         }

--- a/Assets/Scripts/ScreenModuleComponents/Minigames/Drill/DrillNav.cs
+++ b/Assets/Scripts/ScreenModuleComponents/Minigames/Drill/DrillNav.cs
@@ -22,13 +22,13 @@ public class DrillNav : MonoBehaviour
     private void OnTriggerEnter(Collider other)
     {
         if(other.CompareTag("DrillGoal")){
-            goalCollision.RaiseEvent();
+            StartCoroutine(SafeGoalCollision());
             turnoffSiren.RaiseEvent();
-            Debug.Log("Hit the goal!");
+            //Debug.Log("Hit the goal!");
         }
         else if(other.CompareTag("DrillObstacle")){
-            obstacleCollision.RaiseEvent();
-            Debug.Log("Hit an Obstacle!");
+            StartCoroutine(SafeObstacleCollision()); 
+            //Debug.Log("Hit an Obstacle!");
         }
         //Try to find the junction script on the object we just bumped into
         else if (other.TryGetComponent<Junction>(out var junction))
@@ -55,5 +55,23 @@ public class DrillNav : MonoBehaviour
                 // Debug.Log("Successfully loaded onto new preset via Clamper!");
             }
         }
+    }
+
+    System.Collections.IEnumerator SafeObstacleCollision(){
+
+        //Wait until its safe to deload
+        yield return new WaitForFixedUpdate(); 
+
+        //Register Collision
+        obstacleCollision.RaiseEvent();
+    }
+
+    System.Collections.IEnumerator SafeGoalCollision(){
+
+        //Wait until its safe to deload
+        yield return new WaitForFixedUpdate(); 
+
+        //Register Collision
+        goalCollision.RaiseEvent();
     }
 }


### PR DESCRIPTION
…statements

Made the drill minigame win and lose conditions coroutines so that they no longer counted as disabling things on a collision frame and making unity mad.

Commented out debug statement from old tests that were still active (coffee drank and camera state)