### PR TITLE
Terminal disabling, fixed stopinteract

### DIFF
--- a/Assets/Prefabs/Terminals/MainTerminal001.prefab
+++ b/Assets/Prefabs/Terminals/MainTerminal001.prefab
@@ -1272,6 +1272,7 @@ MonoBehaviour:
   startInteract: {fileID: 11400000, guid: f5bda57133b47524fafb7f817f608f23, type: 2}
   stopInteract: {fileID: 11400000, guid: 1618a0b19c317cbf59f09754e973f90e, type: 2}
   setCursorVisibility: {fileID: 11400000, guid: 7f18adf6a3420704e845e1e7511ef534, type: 2}
+  changeObject: {fileID: 11400000, guid: b678fc006b04c4a4eaabca6fff34bf8e, type: 2}
   moduleCamera: {fileID: 87381680730700862}
   Settings: {fileID: 11400000, guid: 550a07fd7d877a444ada2902367f2a50, type: 2}
   distanceFromCamera: 3

--- a/Assets/Prefabs/Terminals/Minigame Manager.prefab
+++ b/Assets/Prefabs/Terminals/Minigame Manager.prefab
@@ -1,5 +1,191 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &365697957076480616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1992215483826151187}
+  - component: {fileID: 8732666655830832434}
+  - component: {fileID: 9190403887059059265}
+  m_Layer: 0
+  m_Name: Block2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1992215483826151187
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365697957076480616}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.753, y: 0.833, z: -1.307}
+  m_LocalScale: {x: 0.35, y: 1, z: 0.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6051176117826794877}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8732666655830832434
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365697957076480616}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &9190403887059059265
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365697957076480616}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &2149470448443714832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2539619927148927419}
+  - component: {fileID: 8665709712194169959}
+  - component: {fileID: 5089921955916602090}
+  m_Layer: 0
+  m_Name: Block1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2539619927148927419
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2149470448443714832}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.579, y: 0.761, z: 0.998}
+  m_LocalScale: {x: 0.3, y: 1, z: 0.28}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6051176117826794877}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8665709712194169959
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2149470448443714832}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &5089921955916602090
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2149470448443714832}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &3212221195258823504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4452184255182798588}
+  - component: {fileID: 4614210592202492868}
+  - component: {fileID: 6053634935996544644}
+  m_Layer: 0
+  m_Name: Block4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &4452184255182798588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3212221195258823504}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.38268343, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: 1.034, y: 0.585, z: 0.869}
+  m_LocalScale: {x: 0.41, y: 1, z: 0.3}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6051176117826794877}
+  m_LocalEulerAnglesHint: {x: 0, y: 45, z: 0}
+--- !u!33 &4614210592202492868
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3212221195258823504}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &6053634935996544644
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3212221195258823504}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6110044856490796021
 GameObject:
   m_ObjectHideFlags: 0
@@ -34,10 +220,14 @@ Transform:
   m_GameObject: {fileID: 6110044856490796021}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.13, y: -4.5936804, z: -11.08}
+  m_LocalPosition: {x: 2.13, y: -4.5936804, z: -12.239}
   m_LocalScale: {x: 7.54, y: 7.54, z: 7.54}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2539619927148927419}
+  - {fileID: 1992215483826151187}
+  - {fileID: 677345345398861890}
+  - {fileID: 4452184255182798588}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7875041204411403159
@@ -67,6 +257,11 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 7c9be3ce742582140a191aeef5c5c426, type: 2}
   efficiencySubtract: {fileID: 11400000, guid: b7e18304678309d8698a60df8672de75, type: 2}
   efficiencyAdd: {fileID: 11400000, guid: 5695c7b8b65fca5369dcef59448b6803, type: 2}
+  blocks:
+  - {fileID: 2149470448443714832}
+  - {fileID: 365697957076480616}
+  - {fileID: 8194493297788579355}
+  - {fileID: 3212221195258823504}
 --- !u!114 &8051398680801365926
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -291,3 +486,65 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &8194493297788579355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 677345345398861890}
+  - component: {fileID: 742547442393761938}
+  - component: {fileID: 5642177319551967883}
+  m_Layer: 0
+  m_Name: Block3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &677345345398861890
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8194493297788579355}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.247, y: 0.81, z: -0.761}
+  m_LocalScale: {x: 0.2, y: 1, z: 0.35}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6051176117826794877}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &742547442393761938
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8194493297788579355}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!65 &5642177319551967883
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8194493297788579355}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Terminals/Terminal2.prefab
+++ b/Assets/Prefabs/Terminals/Terminal2.prefab
@@ -783,6 +783,7 @@ MonoBehaviour:
   startInteract: {fileID: 11400000, guid: 15d381bc5537c67e483e6a1edfda4c5a, type: 2}
   stopInteract: {fileID: 11400000, guid: 1618a0b19c317cbf59f09754e973f90e, type: 2}
   setCursorVisibility: {fileID: 11400000, guid: 7f18adf6a3420704e845e1e7511ef534, type: 2}
+  changeObject: {fileID: 11400000, guid: b678fc006b04c4a4eaabca6fff34bf8e, type: 2}
   moduleCamera: {fileID: 4958701667912424706}
   Settings: {fileID: 11400000, guid: 550a07fd7d877a444ada2902367f2a50, type: 2}
   distanceFromCamera: 0.5

--- a/Assets/Prefabs/Terminals/Terminal3.prefab
+++ b/Assets/Prefabs/Terminals/Terminal3.prefab
@@ -2141,6 +2141,7 @@ MonoBehaviour:
   startInteract: {fileID: 11400000, guid: 3b6dc47944d04034c96464f29ca5ae81, type: 2}
   stopInteract: {fileID: 11400000, guid: 1618a0b19c317cbf59f09754e973f90e, type: 2}
   setCursorVisibility: {fileID: 11400000, guid: 7f18adf6a3420704e845e1e7511ef534, type: 2}
+  changeObject: {fileID: 11400000, guid: b678fc006b04c4a4eaabca6fff34bf8e, type: 2}
   moduleCamera: {fileID: 7299454885066852111}
   Settings: {fileID: 11400000, guid: 550a07fd7d877a444ada2902367f2a50, type: 2}
   distanceFromCamera: 0.5

--- a/Assets/Prefabs/Terminals/Terminal4.prefab
+++ b/Assets/Prefabs/Terminals/Terminal4.prefab
@@ -16832,6 +16832,7 @@ MonoBehaviour:
   startInteract: {fileID: 11400000, guid: b3789425e5ed5ad498baa2632d6ff793, type: 2}
   stopInteract: {fileID: 11400000, guid: 1618a0b19c317cbf59f09754e973f90e, type: 2}
   setCursorVisibility: {fileID: 11400000, guid: 7f18adf6a3420704e845e1e7511ef534, type: 2}
+  changeObject: {fileID: 11400000, guid: b678fc006b04c4a4eaabca6fff34bf8e, type: 2}
   moduleCamera: {fileID: 2999515714031524530}
   Settings: {fileID: 11400000, guid: 550a07fd7d877a444ada2902367f2a50, type: 2}
   distanceFromCamera: 0.5

--- a/Assets/Prefabs/Terminals/Terminal5.prefab
+++ b/Assets/Prefabs/Terminals/Terminal5.prefab
@@ -3448,6 +3448,7 @@ GameObject:
   - component: {fileID: 1563479723886224433}
   - component: {fileID: 8318762475744531659}
   - component: {fileID: 4927219754695296549}
+  - component: {fileID: 5079034066156902788}
   m_Layer: 0
   m_Name: Terminal5
   m_TagString: Untagged
@@ -3567,6 +3568,7 @@ MonoBehaviour:
   startInteract: {fileID: 11400000, guid: e05f97740f7d99c5abe714b8036d3da0, type: 2}
   stopInteract: {fileID: 11400000, guid: 1618a0b19c317cbf59f09754e973f90e, type: 2}
   setCursorVisibility: {fileID: 11400000, guid: 7f18adf6a3420704e845e1e7511ef534, type: 2}
+  changeObject: {fileID: 11400000, guid: b678fc006b04c4a4eaabca6fff34bf8e, type: 2}
   moduleCamera: {fileID: 2048862360701128671}
   Settings: {fileID: 11400000, guid: 550a07fd7d877a444ada2902367f2a50, type: 2}
   distanceFromCamera: 0.5
@@ -3633,6 +3635,34 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: ScreenModule, Assembly-CSharp
         m_MethodName: SetCurrentItemHeld
         m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &5079034066156902788
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3864463892556060292}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSubscriber
+  eventChannel: {fileID: 11400000, guid: 0c69f7aa37e91cb26b63f14f44abf427, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3861565667709715837}
+        m_TargetAssemblyTypeName: ScreenModule, Assembly-CSharp
+        m_MethodName: StopInteract
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -7118,7 +7148,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DrillManager
   startDrillInteract: {fileID: 11400000, guid: e05f97740f7d99c5abe714b8036d3da0, type: 2}
-  stopInteract: {fileID: 11400000, guid: 926885dd11d31814d8b85f38e0857a7a, type: 2}
+  stopInteract: {fileID: 11400000, guid: 0c69f7aa37e91cb26b63f14f44abf427, type: 2}
   drill: {fileID: 4739690742134849691}
   offScreen: {fileID: 585457561389808066}
   DrillPrefabs:

--- a/Assets/ScriptableObjects/ScreenModuleComponents/Minigames/Drill/DrillStopHelper.asset
+++ b/Assets/ScriptableObjects/ScreenModuleComponents/Minigames/Drill/DrillStopHelper.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdc4162389e391144940bf2f69451381, type: 3}
+  m_Name: DrillStopHelper
+  m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSO

--- a/Assets/ScriptableObjects/ScreenModuleComponents/Minigames/Drill/DrillStopHelper.asset.meta
+++ b/Assets/ScriptableObjects/ScreenModuleComponents/Minigames/Drill/DrillStopHelper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c69f7aa37e91cb26b63f14f44abf427
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManagement/MinigameManager.cs
+++ b/Assets/Scripts/GameManagement/MinigameManager.cs
@@ -34,6 +34,8 @@ public class MinigameManager : MonoBehaviour
     bool hasGuaranteedNewMinigame = false;
     int guaranteedNewMinigame = -1;
 
+    [SerializeField] GameObject[] blocks;
+
 
 
     // Awake is called when object is made active
@@ -61,6 +63,28 @@ public class MinigameManager : MonoBehaviour
             if(currentSession.currentDay!=0 && 
                     DayExpectedTriggerWait.Length >= currentSession.currentDay)
             {
+
+                if(currentSession.currentDay<dayEnableMinigame1)
+                {
+                    blocks[0].SetActive(true);
+                    //Debug.Log("Block 1 enabled!");
+                }
+                if(currentSession.currentDay<dayEnableMinigame2)
+                {
+                    blocks[1].SetActive(true);
+                    //Debug.Log("Block 2 enabled!");
+                }
+                if(currentSession.currentDay<dayEnableMinigame3)
+                {
+                    blocks[2].SetActive(true); 
+                    //Debug.Log("Block 3 enabled!");   
+                }
+                if(currentSession.currentDay<dayEnableMinigame4)
+                {
+                    blocks[3].SetActive(true);
+                    //Debug.Log("Block 4 enabled!");
+                }
+
                 //If there's a new minigame today, setup so it will always trigger first.
                 if(currentSession.currentDay==dayEnableMinigame1)
                 {

--- a/Assets/Scripts/ObjectInteraction/InteractableObjectSearcher.cs
+++ b/Assets/Scripts/ObjectInteraction/InteractableObjectSearcher.cs
@@ -141,6 +141,7 @@ public class InteractableObjectSearcher : MonoBehaviour
 
     public void ClearCurrentInteraction()
     {
+        Debug.Log("Current interaction cleared!");
         currentUsable = null;
 
         lastObjectLookedAt?.StopHover();

--- a/Assets/Scripts/ObjectInteraction/Interactables/ScreenModule.cs
+++ b/Assets/Scripts/ObjectInteraction/Interactables/ScreenModule.cs
@@ -6,6 +6,7 @@ public class ScreenModule : MonoBehaviour, IInteractable
     [SerializeField] private VoidEventChannelSO startInteract;
     [SerializeField] private VoidEventChannelSO stopInteract;
     [SerializeField] private BoolEventChannelSO setCursorVisibility;
+    [SerializeField] private GameObjectEventChannelSO changeObject;
     [SerializeField] private Camera moduleCamera;
     [SerializeField] private InteractableSettingsSO Settings;
     [SerializeField] private float distanceFromCamera = 0.5f;
@@ -57,20 +58,26 @@ public class ScreenModule : MonoBehaviour, IInteractable
         isBeingUsed = true;
         playerActionMap.Disable();
         playerMesh.enabled = false;
-        
+        changeObject.RaiseEvent(gameObject);
         CameraSwapper.Instance.SwapCameras(mainCamera, moduleCamera, EnablePlayerInteract);
         PutPlayerInFrontOfScreen();
     }
     
     public void StopInteract()
     {
-        stopInteract.RaiseEvent();
-        setCursorVisibility.RaiseEvent(false);
-        interactAction.Disable();
-        playerMesh.enabled = true;
-        
-        CameraSwapper.Instance.SwapCameras(moduleCamera, mainCamera, EnablePlayerControls);
-        isBeingUsed = false;
+        //Add a check to only run stop interact if we are still currently interacting with a given terminal
+        if(currentItemHeld!=null&&currentItemHeld==gameObject)
+        {
+            //Debug.Log("Stopinteract called from ScreenModule!");
+            stopInteract.RaiseEvent();
+            changeObject.RaiseEvent(null);
+            setCursorVisibility.RaiseEvent(false);
+            interactAction.Disable();
+            playerMesh.enabled = true;
+            
+            CameraSwapper.Instance.SwapCameras(moduleCamera, mainCamera, EnablePlayerControls);
+            isBeingUsed = false;
+        }
     }
     
     public void StartHover()
@@ -87,6 +94,7 @@ public class ScreenModule : MonoBehaviour, IInteractable
     public void SetCurrentItemHeld(GameObject newItemHeld)
     {
         currentItemHeld = newItemHeld;
+        //Debug.Log($"Holding {currentItemHeld}");
     }
 
     private void EnablePlayerInteract()


### PR DESCRIPTION
Stopinteract on the drill minigame no longer halts whatever other action you're doing if you've left the terminal

Terminals now cannot be interacted with until their corresponding enableday in the minigame manager.