### PR TITLE
Minigame tweaks, Audio additions/work

### DIFF
--- a/Assets/Audio/HPC Announcements.meta
+++ b/Assets/Audio/HPC Announcements.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66b6a39d53d1e8e968c65dbe85f96824
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/Dont Forget.wav
+++ b/Assets/Audio/HPC Announcements/Dont Forget.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0650e54a4d07d1b7ade3eedbcbe7796b9d5cd6bd7d888237e3a576df508b5de
+size 1911272

--- a/Assets/Audio/HPC Announcements/Dont Forget.wav.meta
+++ b/Assets/Audio/HPC Announcements/Dont Forget.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 37db76dda012473159c056f9a4a5a334
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/GetWorkMemo.wav
+++ b/Assets/Audio/HPC Announcements/GetWorkMemo.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dcf25ba57353445f235fd21ebad3f78ae7aae5790c2846dfc6dd700e691a614
+size 1623656

--- a/Assets/Audio/HPC Announcements/GetWorkMemo.wav.meta
+++ b/Assets/Audio/HPC Announcements/GetWorkMemo.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 729f9f95916ced615ae154cc878dacae
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/PleaseDrink.wav
+++ b/Assets/Audio/HPC Announcements/PleaseDrink.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cf9f642373e30de8d6692e46b5d8d3c9de1ee7814dc45a6087cd15d1196a105
+size 865640

--- a/Assets/Audio/HPC Announcements/PleaseDrink.wav.meta
+++ b/Assets/Audio/HPC Announcements/PleaseDrink.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 8bca96eba9742ee60a077694dc119b51
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/ReportToEmail.wav
+++ b/Assets/Audio/HPC Announcements/ReportToEmail.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7c64f7798ab5218ba3e183ad35a545ad894fcbc0864e3952cf2ea8bf0939339
+size 1545100

--- a/Assets/Audio/HPC Announcements/ReportToEmail.wav.meta
+++ b/Assets/Audio/HPC Announcements/ReportToEmail.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 49f3856167c7ab361b05f57d8f44737b
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Audio/AudioManager.prefab
+++ b/Assets/Prefabs/Audio/AudioManager.prefab
@@ -94,6 +94,18 @@ MonoBehaviour:
   - clips:
     - {fileID: 8300000, guid: 716677ec75c10f845aecb24454cade15, type: 3}
     type: 15
+  - clips:
+    - {fileID: 8300000, guid: 37db76dda012473159c056f9a4a5a334, type: 3}
+    type: 16
+  - clips:
+    - {fileID: 8300000, guid: 49f3856167c7ab361b05f57d8f44737b, type: 3}
+    type: 17
+  - clips:
+    - {fileID: 8300000, guid: 8bca96eba9742ee60a077694dc119b51, type: 3}
+    type: 18
+  - clips:
+    - {fileID: 8300000, guid: 729f9f95916ced615ae154cc878dacae, type: 3}
+    type: 19
 --- !u!114 &3179720640588262117
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Rooms/Elevator.prefab
+++ b/Assets/Prefabs/Rooms/Elevator.prefab
@@ -1128,6 +1128,10 @@ PrefabInstance:
       propertyPath: openingDoor
       value: 
       objectReference: {fileID: 11400000, guid: 950a5066d1195d9449984bbd9e9dac74, type: 2}
+    - target: {fileID: 5697581609357087480, guid: e2ca524a607c9f142909cc4932adc2cc, type: 3}
+      propertyPath: unlockedSound
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 6013282434390384966, guid: e2ca524a607c9f142909cc4932adc2cc, type: 3}
       propertyPath: m_Mesh
       value: 

--- a/Assets/Prefabs/SceneObjects/CoffeeMachine.prefab
+++ b/Assets/Prefabs/SceneObjects/CoffeeMachine.prefab
@@ -113,10 +113,10 @@ MonoBehaviour:
   requiredItem: EmptyCoffeeCup
   fullCupPrefab: {fileID: 7544416146807603691, guid: 76303dcb27b4b5148a291f2cbab0a128, type: 3}
   settings: {fileID: 11400000, guid: 550a07fd7d877a444ada2902367f2a50, type: 2}
-  numberOfUses: 1
   transitionTime: 0.5
   coffeeLocationBottom: {fileID: 4398285539582711890}
   coffeeSteam: {fileID: 7539481476886722456}
+  onCoffeeMade: 19
 --- !u!114 &2587549803107300851
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/SceneObjects/Doors.prefab
+++ b/Assets/Prefabs/SceneObjects/Doors.prefab
@@ -488,7 +488,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2448519983609853172}
-  - component: {fileID: 8934202508245136059}
   m_Layer: 0
   m_Name: Doors
   m_TagString: Untagged
@@ -515,46 +514,6 @@ Transform:
   - {fileID: 1992946983473187939}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8934202508245136059
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5424940630448750236}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea5f01c6c165438499e822dc6883307c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventChannel: {fileID: 11400000, guid: ac60a04e3c5402349b11243fbfb81d10, type: 2}
-  response:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1735792730575741461}
-        m_TargetAssemblyTypeName: MaterialCorroder, Assembly-CSharp
-        m_MethodName: SetMaterial
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 4954342198824832642}
-        m_TargetAssemblyTypeName: MaterialCorroder, Assembly-CSharp
-        m_MethodName: SetMaterial
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!1 &6975386225980234158
 GameObject:
   m_ObjectHideFlags: 0
@@ -826,3 +785,6 @@ MonoBehaviour:
   openingDoor: {fileID: 11400000, guid: 6204c748b73d5da4197dd90462e9b9c6, type: 2}
   closingDoor: {fileID: 11400000, guid: 2b86215a9bf2c3c4ba6dd304a5bdb6fc, type: 2}
   unlocked: 0
+  unlockedSound: 17
+  lockedSound: 18
+  volume: 1

--- a/Assets/Prefabs/Terminals/Terminal4.prefab
+++ b/Assets/Prefabs/Terminals/Terminal4.prefab
@@ -1672,7 +1672,7 @@ Transform:
   m_GameObject: {fileID: 450275431581138972}
   serializedVersion: 2
   m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 0.984, y: -0.19, z: 0.91}
+  m_LocalPosition: {x: 0.94, y: -0.19, z: 0.91}
   m_LocalScale: {x: 0.03, y: 0.55, z: 0.34965}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2396,7 +2396,7 @@ Transform:
   m_GameObject: {fileID: 831908727307861710}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0.002, y: -0.347, z: -0.05}
+  m_LocalPosition: {x: 0.002, y: -0.358, z: -0.05}
   m_LocalScale: {x: 0.01, y: 0.4, z: 0.49999547}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2958,187 +2958,6 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1071773069478344641}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58ac069886b788341892b9eafadb1276, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mazeCollision: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
---- !u!1 &1113987258246962316
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3632137294317939447}
-  - component: {fileID: 8428755878561418512}
-  - component: {fileID: 2360769340957034023}
-  - component: {fileID: 2779374160495765563}
-  - component: {fileID: 1020857276044969000}
-  m_Layer: 0
-  m_Name: InnerWall (6)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3632137294317939447
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1113987258246962316}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: -0.6493, y: -0.45, z: 0.91}
-  m_LocalScale: {x: 0.8214, y: 0.03, z: 0.34965}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1523344827159401931}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8428755878561418512
-SpriteRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1113987258246962316}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 2
-  m_MaskInteraction: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.8117648, g: 0.7843138, b: 0.5764706, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_SpriteSortPoint: 0
---- !u!61 &2360769340957034023
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1113987258246962316}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &2779374160495765563
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1113987258246962316}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventChannel: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
-  response:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 3858727947589593753}
-        m_TargetAssemblyTypeName: MazeManager, Assembly-CSharp
-        m_MethodName: ResetPlayerToStart
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &1020857276044969000
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1113987258246962316}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 58ac069886b788341892b9eafadb1276, type: 3}
@@ -5538,7 +5357,7 @@ Transform:
   m_GameObject: {fileID: 2784746052440867604}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: -0.00888, y: 0.3484, z: -0.05}
+  m_LocalPosition: {x: -0.00888, y: 0.286, z: -0.05}
   m_LocalScale: {x: 0.01, y: 0.6685769, z: 0.49999547}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6473,14 +6292,11 @@ Transform:
   - {fileID: 4667273805829352147}
   - {fileID: 51100108808653105}
   - {fileID: 7178590635702102917}
-  - {fileID: 6198156362776710154}
   - {fileID: 3583914753926097449}
   - {fileID: 3677603115269990623}
   - {fileID: 4246617882904981116}
-  - {fileID: 1221659416421086061}
   - {fileID: 948034609935209317}
   - {fileID: 3203522573016437602}
-  - {fileID: 3632137294317939447}
   - {fileID: 3865225766525400464}
   - {fileID: 216120914168369658}
   - {fileID: 2182142738931415791}
@@ -7424,7 +7240,7 @@ Transform:
   m_GameObject: {fileID: 4254466587895212911}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0.05748, y: -0.215, z: -0.05}
+  m_LocalPosition: {x: 0.05748, y: -0.236, z: -0.05}
   m_LocalScale: {x: 0.010672299, y: 0.29876184, z: 0.49999547}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -8735,8 +8551,8 @@ Transform:
   m_GameObject: {fileID: 4661252284807503405}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.31981, y: -0.059, z: -0.05}
-  m_LocalScale: {x: 0.011618388, y: 0.567765, z: 0.49999547}
+  m_LocalPosition: {x: 0.31981, y: -0.081, z: -0.05}
+  m_LocalScale: {x: 0.011618388, y: 0.4, z: 0.49999547}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7723783431331925958}
@@ -11179,8 +10995,8 @@ Transform:
   m_GameObject: {fileID: 5891935888740658028}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.203, y: 0.051, z: -0.05}
-  m_LocalScale: {x: 0.01, y: 0.3, z: 0.49999547}
+  m_LocalPosition: {x: 0.203, y: 0.0731, z: -0.05}
+  m_LocalScale: {x: 0.01, y: 0.25, z: 0.49999547}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7723783431331925958}
@@ -12458,187 +12274,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mazeCollision: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
---- !u!1 &6405082130837706491
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1221659416421086061}
-  - component: {fileID: 5084412397408333800}
-  - component: {fileID: 7203881076261725517}
-  - component: {fileID: 3281123590888848271}
-  - component: {fileID: 1988102785143091452}
-  m_Layer: 0
-  m_Name: InnerWall (12)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1221659416421086061
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6405082130837706491}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 1.285, y: -0.051, z: 0.91}
-  m_LocalScale: {x: 0.6, y: 0.03, z: 0.34965}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1523344827159401931}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &5084412397408333800
-SpriteRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6405082130837706491}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 2
-  m_MaskInteraction: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.8117648, g: 0.7843138, b: 0.5764706, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_SpriteSortPoint: 0
---- !u!61 &7203881076261725517
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6405082130837706491}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &3281123590888848271
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6405082130837706491}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventChannel: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
-  response:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 3858727947589593753}
-        m_TargetAssemblyTypeName: MazeManager, Assembly-CSharp
-        m_MethodName: ResetPlayerToStart
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &1988102785143091452
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6405082130837706491}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58ac069886b788341892b9eafadb1276, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mazeCollision: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
 --- !u!1 &6493121303437960246
 GameObject:
   m_ObjectHideFlags: 0
@@ -13029,8 +12664,8 @@ Transform:
   m_GameObject: {fileID: 6754163170197472132}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.341, y: -0.10505, z: -0.05}
-  m_LocalScale: {x: 0.01, y: 0.76006496, z: 0.49999547}
+  m_LocalPosition: {x: -0.341, y: -0.153, z: -0.05}
+  m_LocalScale: {x: 0.01, y: 0.7, z: 0.49999547}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7723783431331925958}
@@ -14115,7 +13750,7 @@ Transform:
   m_GameObject: {fileID: 7116406463053961474}
   serializedVersion: 2
   m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 0.984, y: 0.2237, z: 0.91}
+  m_LocalPosition: {x: 0.941, y: 0.2237, z: 0.91}
   m_LocalScale: {x: 0.03, y: 0.5403523, z: 0.34965}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -14658,8 +14293,8 @@ Transform:
   m_GameObject: {fileID: 7184991990250663786}
   serializedVersion: 2
   m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 0.409, y: -0.23, z: 0.91}
-  m_LocalScale: {x: 0.05, y: 0.98, z: 0.34965}
+  m_LocalPosition: {x: 0.409, y: -0.27, z: 0.91}
+  m_LocalScale: {x: 0.05, y: 0.88, z: 0.34965}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1523344827159401931}
@@ -15020,8 +14655,8 @@ Transform:
   m_GameObject: {fileID: 7283730120806110418}
   serializedVersion: 2
   m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 1.801, y: 0.256, z: 0.91}
-  m_LocalScale: {x: 0.53, y: 0.02, z: 0.34965}
+  m_LocalPosition: {x: 1.855, y: 0.263, z: 0.91}
+  m_LocalScale: {x: 0.4, y: 0.02, z: 0.34965}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1523344827159401931}
@@ -15958,7 +15593,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &738102801921042251
 Transform:
   m_ObjectHideFlags: 0
@@ -16062,7 +15697,7 @@ Transform:
   m_GameObject: {fileID: 7662126636265395688}
   serializedVersion: 2
   m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 0.091, y: -0.863, z: 0.911}
+  m_LocalPosition: {x: 0.659, y: -0.863, z: 0.911}
   m_LocalScale: {x: 1, y: 0.03, z: 0.34965}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -19459,187 +19094,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mazeCollision: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
---- !u!1 &8625747921531675741
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6198156362776710154}
-  - component: {fileID: 9061275257254341072}
-  - component: {fileID: 5290417108341240192}
-  - component: {fileID: 1200054096448762312}
-  - component: {fileID: 5562142760679659170}
-  m_Layer: 0
-  m_Name: InnerWall (24)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6198156362776710154
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8625747921531675741}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: -0.225, y: 0.2589, z: 0.91}
-  m_LocalScale: {x: 0.05, y: 0.17175993, z: 0.34965}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1523344827159401931}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &9061275257254341072
-SpriteRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8625747921531675741}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 2
-  m_MaskInteraction: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.8117648, g: 0.7843138, b: 0.5764706, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_SpriteSortPoint: 0
---- !u!61 &5290417108341240192
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8625747921531675741}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_CompositeOperation: 0
-  m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &1200054096448762312
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8625747921531675741}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  eventChannel: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
-  response:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 3858727947589593753}
-        m_TargetAssemblyTypeName: MazeManager, Assembly-CSharp
-        m_MethodName: ResetPlayerToStart
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &5562142760679659170
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8625747921531675741}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58ac069886b788341892b9eafadb1276, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mazeCollision: {fileID: 11400000, guid: d46ea22cabebd3d4fb63ba9743f6ebdf, type: 2}
 --- !u!1 &8761220429314489648
 GameObject:
   m_ObjectHideFlags: 0
@@ -20613,8 +20067,8 @@ Transform:
   m_GameObject: {fileID: 9087193867642277474}
   serializedVersion: 2
   m_LocalRotation: {x: -0.000000021855694, y: -0, z: -0, w: -1}
-  m_LocalPosition: {x: 0.71, y: 0.499, z: 0.91}
-  m_LocalScale: {x: 0.8, y: 0.02, z: 0.34965}
+  m_LocalPosition: {x: 0.453, y: 0.002, z: 0.91}
+  m_LocalScale: {x: 0.1, y: 0.02, z: 0.34965}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1523344827159401931}

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.Audio;
 using System.Collections.Generic;
+using System.Collections;
 
 public class AudioManager : MonoBehaviour
 {
@@ -8,8 +9,26 @@ public class AudioManager : MonoBehaviour
     private AudioPlayer audioPlayer;
     private MixerController mixerController;
     private Dictionary<SoundType, SoundClip> soundTypeToClip;
+    //For the queue sound type
+    private Dictionary<AudioQueue, Queue<QueuedSound>> audioQueues;
+    private Dictionary<AudioQueue, bool> queuePlaying;
 
     public static AudioManager Instance = null;
+
+    //This is a helper class for specifically queued audio
+    private class QueuedSound
+    {
+        public MixerType mixerType;
+        public SoundType soundType;
+        public float volume;
+
+        public QueuedSound(MixerType mixerType, SoundType soundType, float volume)
+        {
+            this.mixerType = mixerType;
+            this.soundType = soundType;
+            this.volume = volume;
+        }
+    }
 
     void Awake()
     {
@@ -33,6 +52,15 @@ public class AudioManager : MonoBehaviour
         
         audioPlayer = GetComponent<AudioPlayer>();
         mixerController = GetComponent<MixerController>();
+
+        audioQueues = new Dictionary<AudioQueue, Queue<QueuedSound>>();
+        queuePlaying = new Dictionary<AudioQueue, bool>();
+
+        foreach (AudioQueue queue in System.Enum.GetValues(typeof(AudioQueue)))
+        {
+            audioQueues.Add(queue, new Queue<QueuedSound>());
+            queuePlaying.Add(queue, false);
+        }
     }
 
     private void Start()
@@ -124,4 +152,33 @@ public class AudioManager : MonoBehaviour
     {
         return soundTypeToClip[type].GetAudioClip();
     }
+
+    public void PlayQueuedSound(AudioQueue queue, MixerType mixerType, SoundType soundType, float volume)
+    {
+        audioQueues[queue].Enqueue(new QueuedSound(mixerType, soundType, volume));
+
+        if (!queuePlaying[queue])
+        {
+            StartCoroutine(ProcessQueue(queue));
+        }
+    }
+
+    private IEnumerator ProcessQueue(AudioQueue queue)
+    {
+        queuePlaying[queue] = true;
+
+        while (audioQueues[queue].Count > 0)
+        {
+            QueuedSound sound = audioQueues[queue].Dequeue();
+
+            var (mixerGroup, clip) = GetMixerAndClip(sound.mixerType, sound.soundType);
+
+            audioPlayer.PlaySound(mixerGroup, clip, sound.volume);
+
+            yield return new WaitForSeconds(clip.length);
+        }
+
+        queuePlaying[queue] = false;
+    }
+
 }

--- a/Assets/Scripts/Audio/AudioQueue.cs
+++ b/Assets/Scripts/Audio/AudioQueue.cs
@@ -1,0 +1,5 @@
+public enum AudioQueue
+{
+    None,
+    Announcement,
+}

--- a/Assets/Scripts/Audio/AudioQueue.cs.meta
+++ b/Assets/Scripts/Audio/AudioQueue.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41fe04943e5638928819d8bb62ed03ab

--- a/Assets/Scripts/Audio/SoundType.cs
+++ b/Assets/Scripts/Audio/SoundType.cs
@@ -16,4 +16,8 @@ public enum SoundType
     MessageAlert,
     MinigameComplete,
     ScreenTransition,
+    DontForgetAnnouncement,
+    ReportToTerminalAnnouncement,
+    PleaseDrink,
+    GetMemo,
 };

--- a/Assets/Scripts/Doors/DoorMover.cs
+++ b/Assets/Scripts/Doors/DoorMover.cs
@@ -6,6 +6,11 @@ public class DoorMover : MonoBehaviour
     [SerializeField] private VoidEventChannelSO openingDoor;
     [SerializeField] private VoidEventChannelSO closingDoor;
     [SerializeField] private bool unlocked;
+    [SerializeField] private SoundType unlockedSound; //Used for announcements, primarily
+    [SerializeField] private SoundType lockedSound; //Used for announcements, primarily
+    [SerializeField] private float volume = 1f;
+    private bool hasPlayedUnlockedSound = false;
+    private bool hasPlayedlockedSound = false;
     private bool hasEntered;
 
     private void OnTriggerEnter(Collider other)
@@ -16,7 +21,20 @@ public class DoorMover : MonoBehaviour
             openingDoor.RaiseEvent();
 
             AudioManager.Instance.PlaySound(MixerType.SFX, SoundType.DoorOpen, 1f, transform.position);
+            //Play announcement when the player approaches this unlocked door the first time
+            //We only want these to trigger on the first day.
+            if(!hasPlayedUnlockedSound&&LevelManager.Instance.currentSession.currentDay==1)
+            {
+                AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, unlockedSound, volume);
+                hasPlayedUnlockedSound = true;
+            }
         }
+        else if(!unlocked&&!hasPlayedlockedSound)
+        {
+            AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, lockedSound, volume);
+            hasPlayedlockedSound = true;
+        }
+
     }
 
     private void OnTriggerExit(Collider other)

--- a/Assets/Scripts/ObjectInteraction/Interactables/CoffeeMaker.cs
+++ b/Assets/Scripts/ObjectInteraction/Interactables/CoffeeMaker.cs
@@ -11,11 +11,13 @@ public class CoffeeMaker : MonoBehaviour, IInteractable
     [SerializeField] private float transitionTime = .5f;
     [SerializeField] private Transform coffeeLocationBottom;
     [SerializeField] private ParticleSystem coffeeSteam;
+    [SerializeField] private SoundType onCoffeeMade; //Used for announcements, primarily
     private GameObject currentItemHeld;
     private GameObject lastItemheld;
 	private GameObject emptyCup;
     private Outline outline;
     private bool isPlacingCoffee;
+    private bool hasPlayedSound = false;
 
     private void Awake()
     {
@@ -51,6 +53,12 @@ public class CoffeeMaker : MonoBehaviour, IInteractable
     public void StartInteract()
     {
         stopInteraction.RaiseEvent();
+        //Play announcement
+        if(!hasPlayedSound&&LevelManager.Instance.currentSession.currentDay==1)
+        {
+            AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, onCoffeeMade, 1f);
+            hasPlayedSound = true;
+        }
 
         Quaternion currentRotation = lastItemheld.transform.rotation;
         lastItemheld.transform.rotation = Quaternion.identity;

--- a/Assets/Scripts/ScreenModuleComponents/Minigames/Drill/DrillManager.cs
+++ b/Assets/Scripts/ScreenModuleComponents/Minigames/Drill/DrillManager.cs
@@ -9,7 +9,6 @@ public class DrillManager : MonoBehaviour
     [SerializeField] private GameObject[] DrillPrefabs;
     [SerializeField] private Vector3 drillStartPosition;
     private int currentDrillIndex;
-    private int previousDrillIndex;
 
     private bool hasStartedDrill;
     
@@ -56,13 +55,15 @@ public class DrillManager : MonoBehaviour
     {
         DrillPrefabs[currentDrillIndex].SetActive(false);
 
-        // Pick a Drill that is different from the last.
+        int oldIndex = currentDrillIndex;
+
         do
         {
             currentDrillIndex = Random.Range(0, DrillPrefabs.Length);
-        } while (currentDrillIndex == previousDrillIndex && DrillPrefabs.Length > 1);
+        }
+        while (currentDrillIndex == oldIndex && DrillPrefabs.Length > 1);
 
-        previousDrillIndex = currentDrillIndex;
+        DrillPrefabs[currentDrillIndex].SetActive(true);
     }
 
     public void StopDrillInteraction()


### PR DESCRIPTION
Modified maze minigame levels in accordance with playtest feedback Added mutiple announcements
Fixed maze minigame allowing repeat levels
Fixed coffeemachine announcement being replayable past day 1 
Added queue functionality to the audiomanager, with the potential for as many channels as we like
Implemented queue functionality to the current announcements