### PR TITLE
Made camera state modifications

### DIFF
--- a/Assets/Prefabs/SceneObjects/SecurityCamera.prefab
+++ b/Assets/Prefabs/SceneObjects/SecurityCamera.prefab
@@ -360,6 +360,7 @@ GameObject:
   - component: {fileID: 2968444329853537439}
   - component: {fileID: 343728594858216928}
   - component: {fileID: 3745274268890322026}
+  - component: {fileID: 6821706309069783045}
   m_Layer: 3
   m_Name: SecurityCameraBase
   m_TagString: DoorCamera
@@ -474,6 +475,7 @@ MonoBehaviour:
   onCameraRestart: 20
   onCameraSplashed: 21
   onBoxBroken: 23
+  lightOfDoomAndEfficiencyLoss: {fileID: 8582933477677594357}
 --- !u!65 &6893840139946072813
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -570,6 +572,34 @@ MonoBehaviour:
       - m_Target: {fileID: 5396035760417835639}
         m_TargetAssemblyTypeName: SecurityCameraFollow, Assembly-CSharp
         m_MethodName: CMSBoxBroken
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &6821706309069783045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8257725077776436638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSubscriber
+  eventChannel: {fileID: 11400000, guid: dde4955e8dc45fa168a788754a53f3f7, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5396035760417835639}
+        m_TargetAssemblyTypeName: SecurityCameraFollow, Assembly-CSharp
+        m_MethodName: coffeeDrank
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/SceneObjects/SecurityCameraFollow.cs
+++ b/Assets/Scripts/SceneObjects/SecurityCameraFollow.cs
@@ -61,6 +61,12 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
     [SerializeField] private SoundType onCameraSplashed;
     [SerializeField] private SoundType onBoxBroken;
 
+    private bool isAngery = false;
+    private bool isHappe = false;
+
+    [SerializeField] private GameObject lightOfDoomAndEfficiencyLoss;
+
+
     private void Awake()
     {
         StopAllCoroutines();
@@ -94,6 +100,7 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
 
         objectMaterial = GetComponent<Renderer>().material;
         coffeeShaderAmount = Shader.PropertyToID("_Coffee_amount");
+        objectMaterial.SetColor("_Emiss_ON_Color", Color.yellow);
 
         BuildTransitionPath();
     }
@@ -180,7 +187,17 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
         if(((arrived ? (isSplashDay ? 2 : 0) : 3) == 2 || (arrived ? (isSplashDay ? 2 : 0) : 3) == 0) && (state == 1 || state == 3))
         {
             //Debug.Log("Playing cameraRestart Noise!");
-            AudioManager.Instance.PlaySound(MixerType.SFX, onCameraRestart, 1f, transform.position);
+            //Only play restart noise if camera is angry due to cms box breaking. This also prevents overlay with announcement on day 1.
+            if(isAngery)
+            {
+                AudioManager.Instance.PlaySound(MixerType.SFX, onCameraRestart, 1f, transform.position);
+                objectMaterial.SetColor("_Emiss_ON_Color", Color.red);
+                if(lightOfDoomAndEfficiencyLoss!=null)
+                {
+                    lightOfDoomAndEfficiencyLoss.SetActive(true);
+                }
+                
+            }
         }
 
         // Idle label depends on which "idle" applies today - splash day idles at 2, otherwise 0.
@@ -264,6 +281,13 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
             coffee.gameObject.SetActive(true); //Set our coffee drip particles active
             cameraDisabled.RaiseEvent(); //Send a signal (mainly for door to receive to know to open)
             AudioManager.Instance.PlaySound(MixerType.SFX, onCameraSplashed, 1f, transform.position);
+            //Set light to green, get rid of spotlight
+            objectMaterial.SetColor("_Emiss_ON_Color", Color.green);
+            if(lightOfDoomAndEfficiencyLoss!=null)
+            {
+                lightOfDoomAndEfficiencyLoss.SetActive(false);
+            }
+
             objectMaterial.SetFloat(coffeeShaderAmount, 1);
             //Make sure we renable according to the right timer (30s if cannot find day)
             if(LevelManager.Instance!=null)
@@ -273,7 +297,7 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
             }
             else
             {
-                Invoke("reEnableByDayTimer", 30);
+                Invoke("reEnableByDayTimer", 60);
             }
         }
     }
@@ -281,6 +305,26 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
     private void reEnableByDayTimer()
     {
         coffee.gameObject.SetActive(false);
+        if(isAngery)
+        {
+            objectMaterial.SetColor("_Emiss_ON_Color", Color.red);
+            if(lightOfDoomAndEfficiencyLoss!=null)
+            {
+                lightOfDoomAndEfficiencyLoss.SetActive(true);
+            }
+        }
+        else if(isHappe)
+        {
+            objectMaterial.SetColor("_Emiss_ON_Color", Color.green);
+            if(lightOfDoomAndEfficiencyLoss!=null)
+            {
+                lightOfDoomAndEfficiencyLoss.SetActive(false);
+            }
+        }
+        else
+        {
+            objectMaterial.SetColor("_Emiss_ON_Color", Color.yellow);
+        }
         if(LevelManager.Instance!=null)
         {
             state = (LevelManager.Instance.currentSession.currentDay == dayForceSplash) ? 2 : 0;   
@@ -349,6 +393,12 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
 
     public void CMSBoxBroken()
     {
+        isAngery = true;
+        objectMaterial.SetColor("_Emiss_ON_Color", Color.red);
+        if(lightOfDoomAndEfficiencyLoss!=null)
+        {
+            lightOfDoomAndEfficiencyLoss.SetActive(true);
+        }
         StartCoroutine(DegradeEfficiencyRoutine());
     }
 
@@ -381,6 +431,21 @@ public class SecurityCameraFollow : MonoBehaviour, IInteractable
                     hasPlayedWarningSound = true;
                 }
             }
+        }
+    }
+
+    public void coffeeDrank()
+    {
+        if(isAngery)
+        {
+            return; //We don't want this overriding the cms box break since efficiency will still tick down
+        }
+        
+        isHappe = true;
+        objectMaterial.SetColor("_Emiss_ON_Color", Color.green);
+        if(lightOfDoomAndEfficiencyLoss!=null)
+        {
+            lightOfDoomAndEfficiencyLoss.SetActive(false);
         }
     }
 


### PR DESCRIPTION
Camera light now changes color based on state
Green means coffee has been drank or camera is actively disabled Yellow means you have not made a choice yet
Red means the cms box has been broken, and will override green if you then drink coffee after.

Also changed the "restart" sound to only play when the light is red. This prevents it from overlapping with announcements on day 1.