### PR TITLE
Fixes, Voicelines, and Minigame Order

### DIFF
--- a/Assets/Audio/HPC Announcements/NewMinigame1.wav
+++ b/Assets/Audio/HPC Announcements/NewMinigame1.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcd1f782a5b82e813b00068b7f8ee8dbea295e9e1f62115c301b129580ac8877
+size 2575880

--- a/Assets/Audio/HPC Announcements/NewMinigame1.wav.meta
+++ b/Assets/Audio/HPC Announcements/NewMinigame1.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: a6ddf316061361ddca5ca1edf4e7b7fd
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/NewMinigame2.wav
+++ b/Assets/Audio/HPC Announcements/NewMinigame2.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dc01e048eeb4ce80d8274f635c998c3a0058ced1c4b2740335167727cf0b498
+size 2641064

--- a/Assets/Audio/HPC Announcements/NewMinigame2.wav.meta
+++ b/Assets/Audio/HPC Announcements/NewMinigame2.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: c070d815026c467a691f460018439344
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/NewMinigame3.wav
+++ b/Assets/Audio/HPC Announcements/NewMinigame3.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de4edb85bbe987e28167cb77e856083a683331ebb379ff12d8b6f65a6284260b
+size 2854760

--- a/Assets/Audio/HPC Announcements/NewMinigame3.wav.meta
+++ b/Assets/Audio/HPC Announcements/NewMinigame3.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 6a0af5bdd081a0ebea0dcb5405db99a1
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/HPC Announcements/NewMinigame4.wav
+++ b/Assets/Audio/HPC Announcements/NewMinigame4.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cebce8b86eb95be393a1792e40feb5cff18885b832fd7a3b2d4216a8fd230531
+size 2660552

--- a/Assets/Audio/HPC Announcements/NewMinigame4.wav.meta
+++ b/Assets/Audio/HPC Announcements/NewMinigame4.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 290315aad12319257a7dbace35f4aaee
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Audio/AudioManager.prefab
+++ b/Assets/Prefabs/Audio/AudioManager.prefab
@@ -159,6 +159,18 @@ MonoBehaviour:
   - clips:
     - {fileID: 8300000, guid: 38038d334f5560ad48842948f1bf7554, type: 3}
     type: 36
+  - clips:
+    - {fileID: 8300000, guid: a6ddf316061361ddca5ca1edf4e7b7fd, type: 3}
+    type: 37
+  - clips:
+    - {fileID: 8300000, guid: c070d815026c467a691f460018439344, type: 3}
+    type: 38
+  - clips:
+    - {fileID: 8300000, guid: 6a0af5bdd081a0ebea0dcb5405db99a1, type: 3}
+    type: 39
+  - clips:
+    - {fileID: 8300000, guid: 290315aad12319257a7dbace35f4aaee, type: 3}
+    type: 40
 --- !u!114 &3179720640588262117
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -82,7 +82,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: 21300000, guid: 8056ad458a43be74395f1cfa325d6388, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 4c0f6e85235a4b44f98b39da3a9d8e60, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -422,6 +422,7 @@ MonoBehaviour:
   startingDisappear: 0
   serializedDuration: 1.5
   triggerDisappear: {fileID: 11400000, guid: c87fc45fb4e4e9e49b6d9fabbebb934e, type: 2}
+  musicVolume: 0.01
 --- !u!114 &1891783573692545776
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Terminals/Minigame Manager.prefab
+++ b/Assets/Prefabs/Terminals/Minigame Manager.prefab
@@ -251,17 +251,18 @@ MonoBehaviour:
   dayEnableMinigame3: 6
   dayEnableMinigame4: 8
   sirenChannels:
-  - {fileID: 11400000, guid: 3c3a06fcfd4b4c04c9fb2f7744f688c9, type: 2}
-  - {fileID: 11400000, guid: 65b02851cb1c34c4e9904572f9f9e55d, type: 2}
   - {fileID: 11400000, guid: 4835c315706af1f4a94b3802f98514be, type: 2}
+  - {fileID: 11400000, guid: 65b02851cb1c34c4e9904572f9f9e55d, type: 2}
+  - {fileID: 11400000, guid: 3c3a06fcfd4b4c04c9fb2f7744f688c9, type: 2}
   - {fileID: 11400000, guid: 7c9be3ce742582140a191aeef5c5c426, type: 2}
   modifySpeed: {fileID: 11400000, guid: b7e18304678309d8698a60df8672de75, type: 2}
   modifyValue: {fileID: 11400000, guid: 5695c7b8b65fca5369dcef59448b6803, type: 2}
   blocks:
-  - {fileID: 2149470448443714832}
-  - {fileID: 365697957076480616}
   - {fileID: 8194493297788579355}
+  - {fileID: 365697957076480616}
+  - {fileID: 2149470448443714832}
   - {fileID: 3212221195258823504}
+  volume: 1
 --- !u!114 &8051398680801365926
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -274,7 +275,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSubscriber
-  eventChannel: {fileID: 11400000, guid: 3c3a06fcfd4b4c04c9fb2f7744f688c9, type: 2}
+  eventChannel: {fileID: 11400000, guid: 4835c315706af1f4a94b3802f98514be, type: 2}
   response:
     m_PersistentCalls:
       m_Calls:
@@ -302,7 +303,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSubscriber
-  eventChannel: {fileID: 11400000, guid: b654b667d5711914db9f2c5046312650, type: 2}
+  eventChannel: {fileID: 11400000, guid: 0fba5f89468edc446b6f875c15cd0794, type: 2}
   response:
     m_PersistentCalls:
       m_Calls:
@@ -386,7 +387,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSubscriber
-  eventChannel: {fileID: 11400000, guid: 4835c315706af1f4a94b3802f98514be, type: 2}
+  eventChannel: {fileID: 11400000, guid: 3c3a06fcfd4b4c04c9fb2f7744f688c9, type: 2}
   response:
     m_PersistentCalls:
       m_Calls:
@@ -414,7 +415,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95c148139e0d34c4f91eefe4f066375c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::VoidEventChannelSubscriber
-  eventChannel: {fileID: 11400000, guid: 0fba5f89468edc446b6f875c15cd0794, type: 2}
+  eventChannel: {fileID: 11400000, guid: b654b667d5711914db9f2c5046312650, type: 2}
   response:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Prefabs/Terminals/Terminal5.prefab
+++ b/Assets/Prefabs/Terminals/Terminal5.prefab
@@ -278,7 +278,7 @@ Transform:
   m_GameObject: {fileID: 306136326186063899}
   serializedVersion: 2
   m_LocalRotation: {x: 0.5, y: -0.5, z: 0.5, w: 0.5}
-  m_LocalPosition: {x: 0, y: 1.677, z: -0.011000012}
+  m_LocalPosition: {x: 0, y: 1.677, z: -0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -2341,7 +2341,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 3861565667709715837}
         m_TargetAssemblyTypeName: ScreenModule, Assembly-CSharp
-        m_MethodName: StopInteract
+        m_MethodName: 
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4564,6 +4564,7 @@ GameObject:
   - component: {fileID: 1117481500210819898}
   - component: {fileID: 3876588294257015449}
   - component: {fileID: 2630458949292968179}
+  - component: {fileID: 204064936663613270}
   m_Layer: 0
   m_Name: DrillManager
   m_TagString: Untagged
@@ -4801,6 +4802,7 @@ MonoBehaviour:
   - {fileID: 4295445112538036504}
   drillStartPosition: {x: 0, y: 0, z: 9.5}
   onCrash: 27
+  terminal5: {fileID: 3864463892556060292}
 --- !u!114 &3876588294257015449
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4861,6 +4863,34 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: DrillManager, Assembly-CSharp
         m_MethodName: StopDrillInteraction
         m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &204064936663613270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7094126218774461421}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fcdf3cf03da3cb648a17f3fc5c5fb4d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  eventChannel: {fileID: 11400000, guid: b678fc006b04c4a4eaabca6fff34bf8e, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1117481500210819898}
+        m_TargetAssemblyTypeName: DrillManager, Assembly-CSharp
+        m_MethodName: SetCurrentItemHeld
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -6125,6 +6155,10 @@ PrefabInstance:
       propertyPath: switchSprite
       value: 
       objectReference: {fileID: 560746882, guid: d59bd5124f0f293508bbe20a3c632e74, type: 3}
+    - target: {fileID: 860454958384026490, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Capped
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1271335871861701204, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
       propertyPath: m_Name
       value: Drill4
@@ -6132,6 +6166,22 @@ PrefabInstance:
     - target: {fileID: 1271335871861701204, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2647277893678746778, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3771912057807797378, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 3771912057807797378, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078792452593002172, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 5829882651964673495, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6177,6 +6227,22 @@ PrefabInstance:
       propertyPath: trueSprite
       value: 
       objectReference: {fileID: 153878265, guid: d59bd5124f0f293508bbe20a3c632e74, type: 3}
+    - target: {fileID: 8036453508089713188, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8308813897304810840, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8530121643040911590, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 9114884371706176002, guid: 102cf4a52c771f80988a2886171fcde0, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -6200,6 +6266,22 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 8201150775547018878}
     m_Modifications:
+    - target: {fileID: 636775717237000097, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1470457068246734949, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1656097490435417556, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2475174836839831660, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 2475612862984814503, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.048
@@ -6208,9 +6290,33 @@ PrefabInstance:
       propertyPath: m_Name
       value: Drill2
       objectReference: {fileID: 0}
+    - target: {fileID: 2649382945535095048, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2855186312834402010, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.08
+      value: -0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3559912271241495640, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3601146877851246267, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3628467883048313317, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4027813021951315115, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6413315814864517327, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 6691705726864898900, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6219,6 +6325,26 @@ PrefabInstance:
     - target: {fileID: 6691705726864898900, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795379790718437093, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795379790718437093, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 6795379790718437093, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 7529228901901656359, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7906559329827182682, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 8671370262485211398, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6268,9 +6394,37 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0.01
       objectReference: {fileID: 0}
+    - target: {fileID: 8881463891042523864, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 8881463891042523864, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.677
+      objectReference: {fileID: 0}
+    - target: {fileID: 8881463891042523864, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 8926078396417409083, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.024
+      objectReference: {fileID: 0}
+    - target: {fileID: 8926078396417409083, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062297540307898923, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062297540307898923, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 9062297540307898923, guid: 017363da221c0f3578b7d86b476ac1cc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -6295,6 +6449,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 8201150775547018878}
     m_Modifications:
+    - target: {fileID: 253481454170908290, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 301344288345861457, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
       propertyPath: m_LocalPosition.x
       value: 5.82
@@ -6335,9 +6493,73 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 617014080464773943, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1198289484103689294, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283001145658772254, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1314744989858275275, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1647708874964220922, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2425825911483797284, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3280478311643280020, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3419759672670353527, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3974297493479414258, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
       propertyPath: m_Name
       value: Drill3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3974297493479414258, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4394739115532190291, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4553834052314043163, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5218867453759382102, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5566322838457372104, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6573354981046149895, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7686618469714241652, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8581794680442687517, guid: 4f4c9f420240dfaf58426fe534645b61, type: 3}
+      propertyPath: m_Mesh
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -115,7 +115,9 @@ public class AudioManager : MonoBehaviour
     {
         var (mixerGroup, clip) = GetMixerAndClip(mixerType, soundType);
 
-        return audioPlayer.PlaySoundLoop(mixerGroup, clip, volume);
+        GameObject loopObject = audioPlayer.PlaySoundLoop(mixerGroup, clip, volume);
+        TrackLoopedSound(loopObject);
+        return loopObject;
     }
 
     /// <summary>
@@ -126,7 +128,9 @@ public class AudioManager : MonoBehaviour
     {
         var (mixerGroup, clip) = GetMixerAndClip(mixerType, soundType);
 
-        return audioPlayer.PlaySoundLoop(mixerGroup, clip, volume, position);
+        GameObject loopObject = audioPlayer.PlaySoundLoop(mixerGroup, clip, volume, position);
+        TrackLoopedSound(loopObject);
+        return loopObject;
     }
 
     /// <summary>
@@ -137,7 +141,9 @@ public class AudioManager : MonoBehaviour
     {
         var (mixerGroup, clip) = GetMixerAndClip(mixerType, soundType);
 
-        return audioPlayer.PlaySoundLoop(mixerGroup, clip, volume, parent);
+        GameObject loopObject = audioPlayer.PlaySoundLoop(mixerGroup, clip, volume, parent);
+        TrackLoopedSound(loopObject);
+        return loopObject;
     }
 
     private (AudioMixerGroup, AudioClip) GetMixerAndClip(MixerType mixerType, SoundType soundType)
@@ -179,6 +185,51 @@ public class AudioManager : MonoBehaviour
         }
 
         queuePlaying[queue] = false;
+    }
+
+    //This makes sure all looped audio is stopped when officeworkplace is loaded.
+    private const string OfficeSceneName = "OfficeWorkplace";
+
+    private readonly List<GameObject> activeLoopedSounds = new List<GameObject>();
+
+    private void OnEnable()
+    {
+        UnityEngine.SceneManagement.SceneManager.sceneUnloaded += HandleSceneUnloaded;
+    }
+
+    private void OnDisable()
+    {
+        UnityEngine.SceneManagement.SceneManager.sceneUnloaded -= HandleSceneUnloaded;
+    }
+
+    private void TrackLoopedSound(GameObject loopObject)
+    {
+        if (loopObject == null) return;
+        activeLoopedSounds.Add(loopObject);
+    }
+
+    private void HandleSceneUnloaded(UnityEngine.SceneManagement.Scene scene)
+    {
+        if (scene.name != OfficeSceneName) return;
+
+        StopAllLoopedSounds();
+    }
+
+    /// <summary>
+    /// Immediately stops (destroys) every looped sound currently tracked.
+    /// </summary>
+    public void StopAllLoopedSounds()
+    {
+        for (int i = 0; i < activeLoopedSounds.Count; i++)
+        {
+            GameObject loopObject = activeLoopedSounds[i];
+            if (loopObject != null)
+            {
+                Destroy(loopObject);
+            }
+        }
+
+        activeLoopedSounds.Clear();
     }
 
 }

--- a/Assets/Scripts/GameManagement/MinigameManager.cs
+++ b/Assets/Scripts/GameManagement/MinigameManager.cs
@@ -35,6 +35,8 @@ public class MinigameManager : MonoBehaviour
 	
     [SerializeField] GameObject[] blocks;
 
+    [SerializeField] private float volume = 1f;
+
     // Awake is called when object is made active
     void Awake()
     {
@@ -130,6 +132,20 @@ public class MinigameManager : MonoBehaviour
             if(hasGuaranteedNewMinigame)
             {
                 nextGame = guaranteedNewMinigame;
+                switch(nextGame){
+                    case 0:
+                    AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, SoundType.NewMiniGame3, volume);
+                    break;
+                    case 1:
+                    AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, SoundType.NewMiniGame2, volume);
+                    break;
+                    case 2:
+                    AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, SoundType.NewMiniGame1, volume);
+                    break;
+                    case 3:
+                    AudioManager.Instance.PlayQueuedSound(AudioQueue.Announcement, MixerType.SFX, SoundType.NewMiniGame4, volume);
+                    break;
+                }
                 hasGuaranteedNewMinigame = false;
             }
             else//Default case of randomization

--- a/Assets/Scripts/ScreenModuleComponents/Minigames/Drill/DrillManager.cs
+++ b/Assets/Scripts/ScreenModuleComponents/Minigames/Drill/DrillManager.cs
@@ -14,9 +14,13 @@ public class DrillManager : MonoBehaviour
     private bool hasStartedDrill;
 
     [SerializeField] private SoundType onCrash;
+
+    private GameObject currentItemHeld;
+    [SerializeField] private GameObject terminal5;
     
     void Awake()
     {
+        currentItemHeld = null;
         currentDrillIndex = Random.Range(0, DrillPrefabs.Length);
         //DrillPrefabs[currentDrillIndex].SetActive(true); //Old method of loading, caused things to start before terminal got touched
 
@@ -79,14 +83,11 @@ public class DrillManager : MonoBehaviour
         hasStartedDrill = false;
 
 
-        if(stopInteract != null)
+        if(stopInteract != null&&currentItemHeld!=null&&currentItemHeld==terminal5)
         {
             stopInteract.RaiseEvent();
         }
-		if(drillStopHelper != null)
-		{
-			drillStopHelper.RaiseEvent();
-		}
+
         AudioManager.Instance.PlaySound(MixerType.SFX, SoundType.MinigameComplete, 1f, transform.position);
         TurnScreenOff(true);     
         ResetDrillToStart();
@@ -98,6 +99,12 @@ public class DrillManager : MonoBehaviour
     public void PlayCrashSound()
     {
         AudioManager.Instance.PlaySound(MixerType.SFX, onCrash, 0.7f, transform.position);
+    }
+
+    public void SetCurrentItemHeld(GameObject newItemHeld)
+    {
+        currentItemHeld = newItemHeld;
+        //Debug.Log($"Holding {currentItemHeld}");
     }
     
 }

--- a/Assets/Scripts/ScreenModuleComponents/Minigames/Matching/MatchingManager.cs
+++ b/Assets/Scripts/ScreenModuleComponents/Minigames/Matching/MatchingManager.cs
@@ -296,16 +296,16 @@ public class MatchingManager : MonoBehaviour
 	{
 		switch(which){
 				case 0:
-					AudioManager.Instance.PlaySound(MixerType.SFX, Button1Sound, 0.7f);
+					AudioManager.Instance.PlaySound(MixerType.SFX, Button1Sound, 0.1f);
 					break;
 				case 1:
-					AudioManager.Instance.PlaySound(MixerType.SFX, Button2Sound, 0.7f);
+					AudioManager.Instance.PlaySound(MixerType.SFX, Button2Sound, 0.1f);
 					break;
 				case 2:
-					AudioManager.Instance.PlaySound(MixerType.SFX, Button3Sound, 0.7f);
+					AudioManager.Instance.PlaySound(MixerType.SFX, Button3Sound, 0.1f);
 					break;
 				case 3:
-					AudioManager.Instance.PlaySound(MixerType.SFX, Button4Sound, 0.7f);
+					AudioManager.Instance.PlaySound(MixerType.SFX, Button4Sound, 0.1f);
 					break;
 		}
 	}


### PR DESCRIPTION
Fixed issue where player would be forced to stopinteract when drill minigame finished 
Fixed issue where music could persist past the officeworkplace scene 
Repositioned junctions in the drill minigame to better fit the paths they're on 
Added audio to each time a new minigame shows up and is guaranteed to trigger (4 new voicelines) 
Cut volume on matching minigame beeps to 1/7th previous 
Changed order of minigames so that maze shows day 6 instead of 2, and matching minigame takes its spot on day 2.